### PR TITLE
Draft of block-based layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Let's just jump into the code. Here's the header file.
 // MyView.h
 #import <YOLayout/YOView.h>
 
-//! A view that sizes vertically based on the height of a label and an image view
+//! A view that sizes vertically based the size of its subviews
 @interface MyView : YOView
 @end
 ```
@@ -19,34 +19,33 @@ Here's the implementation file. This view's height can change based on the Dynam
 ```Objective-C
 // MyView.m
 #import "MyView.h"
- 
-@interface MyView ()
-@property UIImageView *imageView;
-@property DynamicHeightSubview *dynamicHeightSubview;
-@end
- 
+
 @implementation MyView
 
+// sharedInit is called from both initWithFrame: and initWithCoder:
 - (void)sharedInit {
-    self.layout = [YOLayout layoutWithView:self];
+    // Create this view's subviews
+    UIImageView *imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"MyImage.png"]];
+    [self addSubview:imageView];
+    DynamicHeightSubview *dynamicHeightSubview = [[DynamicHeightSubview alloc] init];
+    [self addSubview:dynamicHeightSubview];
  
-    _imageView = [[UIImageView alloc] initWithImage:[UIImage imageNamed:@"MyImage.png"]];
-    [self addSubview:_imageView];
-    _dynamicHeightSubview = [[DynamicHeightSubview alloc] init];
-    [self addSubview:_dynamicHeightSubview];
+    // Define the layout using code, and math!
+    [self setLayoutBlock:^(id<YOLayout> layout, CGSize size) {
+        CGFloat x = 10;
+        CGFloat y = 10;
+ 
+        // Instead of setting frames directly, we use the corresponding layout methods.
+        // These methods don't actually change the subviews' frames when the view is just sizing.
+        x += [layout setOrigin:CGPointMake(x, y) view:_imageView].size.width + 10;
+
+        y += [layout setFrame:CGRectMake(x, y, size.width - x - 10, 0) sizeThatFits:YES].size.height;
+
+        // The size this view should be
+        return CGSizeMake(size.width, y);
+    }];
 }
- 
-- (CGSize)layout:(id<YOLayout>)layout size:(CGSize)size {
-    CGFloat x = 10;
-    CGFloat y = 10;
-    
-    x += [layout setOrigin:CGPointMake(x, y) view:_imageView].size.width + 10;
-    
-    y += [layout setFrame:CGRectMake(x, y, size.width - x - 10, 0) sizeThatFits:YES].size.height;
-    
-    return CGSizeMake(size.width, y);
-}
- 
+
 @end
 ```
 

--- a/YOLayout/YOView.h
+++ b/YOLayout/YOView.h
@@ -11,22 +11,17 @@
 /*!
  View with custom, programatic layout (via YOLayout).
  
- Instead of subclassing UIView, you can subclass YOView and implement
- sharedInit and layout:size:. See YOLayout for more details.
- 
- 
+ Instead of subclassing UIView, you can subclass YOView and set the layout property.
+ See YOLayout for more details.
+
       - (void)sharedInit {
          [super sharedInit];
-         self.layout = [YOLayout layoutForView:self];
+         self.layout = [YOLayout layoutForView:self layoutBlock:^(id<YOLayout> layout, CGSize size) {
+           [layout setFrame:CGRectMake(0, 0, size.width, 30)];
+           return CGSizeMake(size.width, 30);
+         }];
          self.backgroundColor = [UIColor whiteColor];
       }
- 
-      - (CGSize)layout:(id<YOLayout>)layout size:(CGSize)size {
-         [layout setFrame:CGRectMake(0, 0, size.width, 30)];
-         return CGSizeMake(size.width, 30);
-      }
- 
- 
  */
 @interface YOView : UIView <YOLayoutView> { }
 
@@ -36,6 +31,12 @@
  Subclasses can override this method to perform initialization tasks that occur during both initWithFrame: and initWithCoder:
  */
 - (void)sharedInit;
+
+/*!
+ Set the layout block for this view. A YOLayout object will be generated as well, if necessary
+ Note: This is a method, not a parameter for easy autocompletion of the block type.
+ */
+- (void)setLayoutBlock:(YOLayoutBlock)layoutBlock;
 
 /*!
  Set if needs refresh.

--- a/YOLayout/YOView.m
+++ b/YOLayout/YOView.m
@@ -44,6 +44,14 @@
   }
 }
 
+- (void)setLayoutBlock:(YOLayoutBlock)layoutBlock {
+  if (!self.layout) {
+    self.layout = [YOLayout layoutForView:self layoutBlock:layoutBlock];
+  } else {
+    self.layout.layoutBlock = layoutBlock;
+  }
+}
+
 - (void)setAttributesNeedUpdate:(NSArray *)attributes {
   if (!_observeAttributes) _observeAttributes = [NSMutableArray array];
   [_observeAttributes addObjectsFromArray:attributes];


### PR DESCRIPTION
Taking a stab at block-based layouts for YOLayout. Instead of implementing layout:size:, views instead specify a layout block that does the same thing. The advantages are
- You don't need to maintain references to your subviews just for layouts
- You can potentially build a view hierarchy without subclassing views.

One design decision that I'm still on the fence about was adding a convenience method `setLayoutBlock` to YOView. Not sure if this adds much. With the convenience method, you define a layout block like this:

```
[self setLayoutBlock:^(id<YOLayout> layout, CGSize size) {
```

Without it you'd do this:

```
self.layout = [YOLayout layoutForView:self layoutBlock:^(id<YOLayout> layout, CGSize size) {
```

Because autocomplete is so good in XCode not sure if much is gained from the first part. Looks simpler, but maybe makes the layout system a little more opaque in how it works. I go back and forth on this.
