### PR TITLE
Splitting YOLayoutOptionsSizeToFitDefaultSize into height and width options

### DIFF
--- a/YOLayout/YOCGUtils.h
+++ b/YOLayout/YOCGUtils.h
@@ -1,5 +1,5 @@
 //
-//  YOLayout.h
+//  YOCGUtils.h
 //  YOLayout
 //
 //  Created by Gabriel Handford on 10/29/13.

--- a/YOLayout/YOCGUtils.m
+++ b/YOLayout/YOCGUtils.m
@@ -1,5 +1,5 @@
 //
-//  YOCGUtils.c
+//  YOCGUtils.m
 //  YOLayout
 //
 //  Created by Gabriel Handford on 10/29/13.

--- a/YOLayout/YOLayout.h
+++ b/YOLayout/YOLayout.h
@@ -14,41 +14,53 @@
 
 typedef enum {
   // SIZING
-  // Size the view to fit vertically
+  //! Size the view to fit vertically
   YOLayoutOptionsSizeToFitVertical = 1 << 0,
-  // Size the view to fit horizontally
+  //! Size the view to fit horizontally
   YOLayoutOptionsSizeToFitHorizontal = 1 << 1,
+  //! Size the view to fit both horizontally and vertically
   YOLayoutOptionsSizeToFit = YOLayoutOptionsSizeToFitVertical | YOLayoutOptionsSizeToFitHorizontal,
 
-  // Constrain sizeThatFit's width to the pased in frame
-  // For example UILabel sizeToFit may return a larger width than was specified,
-  // and this will constrain it.
+  /*!
+   Constrain sizeThatFit's width to the passed in frame.
+
+   For example, UILabel sizeThatFits: may return a larger width than was specified, and this will constrain it.
+   */
   YOLayoutOptionsSizeToFitConstrainWidth = 1 << 2,
-
-  // Constrain sizeThatFit's height to the pased in frame
+  //! Constrain sizeThatFit's height to the passed in frame
   YOLayoutOptionsSizeToFitConstrainHeight = 1 << 3,
+  //! Constrain sizeThatFit's height and width
+  YOLayoutOptionsSizeToFitConstrain = YOLayoutOptionsSizeToFitConstrainWidth | YOLayoutOptionsSizeToFitConstrainHeight,
 
-  // Constrain sizeThatFits to the size specified but maintain the original aspect ratio.
-  // This is useful for an image view that may need to be constrained to a max
-  // size, but still maintain its aspect ratio.
+  /*!
+   Constrain sizeThatFits to the size specified but maintain the original aspect ratio.
+
+   This is useful for an image view that may need to be constrained to a max size, but still maintain its aspect ratio.
+   */
   YOLayoutOptionsSizeToFitConstrainSizeMaintainAspectRatio = 1 << 4,
 
-  // Whether the size specified is the default. Using this option will
-  // use the specified width and/or height (if not 0) when the sizeToFit
-  // returns a 0 width and/or height.
-  // This is useful for an image view that has to load its data and may
-  // initially return 0 for sizeThatFits.
+  //! Whether the height specified is the default. Using this option will use the specified height when sizeThatFits: returns a 0 height.
   YOLayoutOptionsSizeToFitDefaultHeight = 1 << 5,
+  //! Whether the width specified is the default. Using this option will use the specified width when sizeThatFits: returns a 0 width.
   YOLayoutOptionsSizeToFitDefaultWidth = 1 << 6,
+  /*!
+   Whether the size specified is the default. Using this option will use the specified width and/or height when sizeThatFits: returns a 0 width and/or height, respectively.
+
+   This is useful for an image view that has to load its data and may initially return 0 for sizeThatFits.
+   */
   YOLayoutOptionsSizeToFitDefault = YOLayoutOptionsSizeToFitDefaultHeight | YOLayoutOptionsSizeToFitDefaultWidth,
 
   // ALIGNMENT
-  // Center the view in the specified size. If you use this with YOLayoutOptionsSizeToFit then the origin width is maintained.
-  YOLayoutOptionsAlignCenterVertical = 1 << 10, // Center vertically
-  YOLayoutOptionsAlignCenterHorizontal = 1 << 11, // Center horizontally
+  //! After sizing, center vertically in the passed in rect
+  YOLayoutOptionsAlignCenterVertical = 1 << 10,
+  //! After sizing, center horizontally in the passed in rect
+  YOLayoutOptionsAlignCenterHorizontal = 1 << 11,
+  //! After sizing, center vertically and horizontally in the passed in rect
   YOLayoutOptionsAlignCenter = YOLayoutOptionsAlignCenterVertical | YOLayoutOptionsAlignCenterHorizontal,
-  YOLayoutOptionsAlignRight = 1 << 12, // After sizing, aligns the view with the right of the passed in rect
-  YOLayoutOptionsAlignBottom = 1 << 13, // After sizing, aligns the view with the bottom of the passed in rect
+  // After sizing, aligns the view with the right of the passed in rect
+  YOLayoutOptionsAlignRight = 1 << 12,
+  // After sizing, aligns the view with the bottom of the passed in rect
+  YOLayoutOptionsAlignBottom = 1 << 13,
 } YOLayoutOptions;
 
 

--- a/YOLayout/YOLayout.h
+++ b/YOLayout/YOLayout.h
@@ -35,10 +35,12 @@ typedef enum {
 
   // Whether the size specified is the default. Using this option will
   // use the specified width and/or height (if not 0) when the sizeToFit
-  // returns a 0 width.
+  // returns a 0 width and/or height.
   // This is useful for an image view that has to load its data and may
   // initially return 0 for sizeThatFits.
-  YOLayoutOptionsSizeToFitDefaultSize = 1 << 5,
+  YOLayoutOptionsSizeToFitDefaultHeight = 1 << 5,
+  YOLayoutOptionsSizeToFitDefaultWidth = 1 << 6,
+  YOLayoutOptionsSizeToFitDefault = YOLayoutOptionsSizeToFitDefaultHeight | YOLayoutOptionsSizeToFitDefaultWidth,
 
   // ALIGNMENT
   // Center the view in the specified size. If you use this with YOLayoutOptionsSizeToFit then the origin width is maintained.

--- a/YOLayout/YOLayout.m
+++ b/YOLayout/YOLayout.m
@@ -125,11 +125,11 @@
       }
     }
 
-    if (sizeThatFits.width == 0 && ((options & YOLayoutOptionsSizeToFitDefaultWidth) == YOLayoutOptionsSizeToFitDefaultWidth)) {
+    if (sizeThatFits.width == 0 && ((options & YOLayoutOptionsSizeToFitDefaultWidth) != 0)) {
       sizeThatFits.width = frame.size.width;
     }
     
-    if (sizeThatFits.height == 0 && ((options & YOLayoutOptionsSizeToFitDefaultHeight) == YOLayoutOptionsSizeToFitDefaultHeight)) {
+    if (sizeThatFits.height == 0 && ((options & YOLayoutOptionsSizeToFitDefaultHeight) != 0)) {
       sizeThatFits.height = frame.size.height;
     }
 

--- a/YOLayout/YOLayout.m
+++ b/YOLayout/YOLayout.m
@@ -125,11 +125,11 @@
       }
     }
 
-    if (sizeThatFits.width == 0 && ((options & YOLayoutOptionsSizeToFitDefaultSize) == YOLayoutOptionsSizeToFitDefaultSize)) {
+    if (sizeThatFits.width == 0 && ((options & YOLayoutOptionsSizeToFitDefaultWidth) == YOLayoutOptionsSizeToFitDefaultWidth)) {
       sizeThatFits.width = frame.size.width;
     }
     
-    if (sizeThatFits.height == 0 && ((options & YOLayoutOptionsSizeToFitDefaultSize) == YOLayoutOptionsSizeToFitDefaultSize)) {
+    if (sizeThatFits.height == 0 && ((options & YOLayoutOptionsSizeToFitDefaultHeight) == YOLayoutOptionsSizeToFitDefaultHeight)) {
       sizeThatFits.height = frame.size.height;
     }
 


### PR DESCRIPTION
Created two new options:
`YOLayoutOptionsSizeToFitDefaultHeight`
`YOLayoutOptionsSizeToFitDefaultWidth`

and renaming `YOLayoutOptionsSizeToFitDefaultSize` option to be a derived option named `YOLayoutOptionsSizeToFitDefault`

Also cleaned up `YOLayoutOptions` comments using `//!` and `/*! */` so that the comments show up when you option+click the `YOLayoutOptions`