### PR TITLE
Splitting out size/rect alignment code

### DIFF
--- a/YOLayout/YOLayout_IMP.h
+++ b/YOLayout/YOLayout_IMP.h
@@ -154,12 +154,24 @@ typedef NS_ENUM (NSInteger, YOLayoutOptions) {
  Set the size in rect with options.
  
  @param size Desired size (or size hint if using YOLayoutOptionsSizeToFit)
- @param inRect Rect in which to position the view. `inRect.size` may be different than `size` when using this method with YOLayoutOptionsCenter, YOLayoutOptionsCenterVertical, YOLayoutOptionsRightAlign, etc.
+ @param inRect Rect in which to position the view. `inRect.size` may be different than `size` when using this method with YOLayoutOptionsAlign options.
  @param view View
  @param options Options See YOLayoutOptions for more info
  @result The view frame.
  */
 - (CGRect)setSize:(CGSize)size inRect:(CGRect)inRect view:(id)view options:(YOLayoutOptions)options;
+
+/*!
+ Get the frame for size in rect with options. Useful for precalculating layout frames before the associated view exists.
+
+ NOTE: This ignores any YOLayoutOption that doesn't begin with YOLayoutOptionAlign
+
+ @param size Desired size
+ @param inRect Rect in which to position the view. `inRect.size` may be different than `size` when using this method with YOLayoutOptionsAlign options.
+ @param options Options See YOLayoutOptions for more info
+ @result The view frame.
+ */
+- (CGRect)alignedRectForSize:(CGSize)size inRect:(CGRect)inRect options:(YOLayoutOptions)options;
 
 /*!
  Set origin. Same as setFrame:view: but uses the existing view.frame.size.

--- a/YOLayout/YOLayout_IMP.m
+++ b/YOLayout/YOLayout_IMP.m
@@ -93,8 +93,33 @@ const UIEdgeInsets UIEdgeInsetsZero = {0, 0, 0, 0};
   return [self setSize:size inRect:frame view:view options:options];
 }
 
-- (CGRect)setSize:(CGSize)size inRect:(CGRect)inRect view:(id)view options:(YOLayoutOptions)options {
+- (CGRect)alignedRectForSize:(CGSize)size inRect:(CGRect)inRect options:(YOLayoutOptions)options {
+  // If we passed in 0 for inRect height or width, then lets set it to the frame height or width.
+  // This usually happens if we are sizing to fit, and is needed to align below.
+  if (inRect.size.width == 0) inRect.size.width = size.width;
+  if (inRect.size.height == 0) inRect.size.height = size.height;
+  
+  CGPoint p = inRect.origin;
+  if ((options & YOLayoutOptionsAlignCenterHorizontal) != 0) {
+    p.x += YOCGPointToCenterX(size, inRect.size).x;
+  }
+  
+  if ((options & YOLayoutOptionsAlignCenterVertical) != 0) {
+    p.y += YOCGPointToCenterY(size, inRect.size).y;
+  }
+  
+  if ((options & YOLayoutOptionsAlignRight) != 0) {
+    p.x = inRect.origin.x + inRect.size.width - size.width;
+  }
+  
+  if ((options & YOLayoutOptionsAlignBottom) != 0) {
+    p.y = inRect.origin.y + inRect.size.height - size.height;
+  }
+  
+  return CGRectMake(p.x, p.y, size.width, size.height);
+}
 
+- (CGRect)setSize:(CGSize)size inRect:(CGRect)inRect view:(id)view options:(YOLayoutOptions)options {
   CGSize originalSize = size;
   BOOL sizeToFit = ((options & YOLayoutOptionsSizeToFitHorizontal) != 0)
     || ((options & YOLayoutOptionsSizeToFitVertical) != 0);
@@ -146,29 +171,7 @@ const UIEdgeInsets UIEdgeInsetsZero = {0, 0, 0, 0};
     size.height = originalSize.height;
   }
 
-  // If we passed in 0 for inRect height or width, then lets set it to the frame height or width.
-  // This usually happens if we are sizing to fit, and is needed to align below.
-  if (inRect.size.width == 0) inRect.size.width = size.width;
-  if (inRect.size.height == 0) inRect.size.height = size.height;
-
-  CGPoint p = inRect.origin;
-  if ((options & YOLayoutOptionsAlignCenterHorizontal) != 0) {
-    p.x += YOCGPointToCenterX(size, inRect.size).x;
-  }
-
-  if ((options & YOLayoutOptionsAlignCenterVertical) != 0) {
-    p.y += YOCGPointToCenterY(size, inRect.size).y;
-  }
-
-  if ((options & YOLayoutOptionsAlignRight) != 0) {
-    p.x = inRect.origin.x + inRect.size.width - size.width;
-  }
-
-  if ((options & YOLayoutOptionsAlignBottom) != 0) {
-    p.y = inRect.origin.y + inRect.size.height - size.height;
-  }
-
-  CGRect frame = CGRectMake(p.x, p.y, size.width, size.height);
+  CGRect frame = [self alignedRectForSize:size inRect:inRect options:options];
   [self setFrame:frame view:view];
 
   return frame;


### PR DESCRIPTION
Ran into a case today where I needed to know the frames for imageViews before I had instantiated them, so I knew how to animate them in once I created them.

This change splits out the alignment into a new method that calculates the aligned rect given a size and a rect.
```
    - (CGRect)alignedRectForSize:(CGSize)size inRect:(CGRect)inRect options:(YOLayoutOptions)options;
```
Not super attached to this. It's a little weird that it only accepts the YOLayoutOptionsAlign options. But I found it useful today.

In fact, the more I stare at it, the more I realize how small of a niche this will fill. What do you think?