### PR TITLE
Swift circle layout example

### DIFF
--- a/YOLayout/YOLayout_IMP.h
+++ b/YOLayout/YOLayout_IMP.h
@@ -35,7 +35,7 @@ static inline NSString *YONSStringFromCGSize(CGSize size) {
 }
 #endif
 
-typedef NS_ENUM (NSInteger, YOLayoutOptions) {
+typedef NS_OPTIONS (NSUInteger, YOLayoutOptions) {
   YOLayoutOptionsNone = 0,
   // SIZING
   //! Size the view to fit vertically

--- a/YOLayoutExample/YOLayoutExample.xcodeproj/project.pbxproj
+++ b/YOLayoutExample/YOLayoutExample.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		00D52F521A6F2BA600DEB5F5 /* YONSTestView.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D52F511A6F2BA600DEB5F5 /* YONSTestView.m */; };
 		00D52F581A6F2C6100DEB5F5 /* YONSLabel.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D52F561A6F2C6100DEB5F5 /* YONSLabel.m */; };
 		00D52F5B1A6F2CA200DEB5F5 /* YONSButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 00D52F5A1A6F2CA200DEB5F5 /* YONSButton.m */; };
+		4255D4A71AB35116004CB409 /* CircleLayoutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4255D4A51AB35116004CB409 /* CircleLayoutView.swift */; };
+		4255D4A81AB35116004CB409 /* SwiftViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4255D4A61AB35116004CB409 /* SwiftViewController.swift */; };
 		426C0FCA1A41606800F2577C /* information.png in Resources */ = {isa = PBXBuildFile; fileRef = 426C0FC71A41606800F2577C /* information.png */; };
 		426C0FCB1A41606800F2577C /* information@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 426C0FC81A41606800F2577C /* information@2x.png */; };
 		426C0FCC1A41606800F2577C /* information@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 426C0FC91A41606800F2577C /* information@3x.png */; };
@@ -75,6 +77,9 @@
 		00D52F571A6F2C6100DEB5F5 /* YONSLabel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YONSLabel.h; sourceTree = "<group>"; };
 		00D52F591A6F2CA200DEB5F5 /* YONSButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = YONSButton.h; sourceTree = "<group>"; };
 		00D52F5A1A6F2CA200DEB5F5 /* YONSButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = YONSButton.m; sourceTree = "<group>"; };
+		4255D4A41AB35115004CB409 /* YOLayoutExample-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "YOLayoutExample-Bridging-Header.h"; sourceTree = "<group>"; };
+		4255D4A51AB35116004CB409 /* CircleLayoutView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = CircleLayoutView.swift; path = SwiftView/CircleLayoutView.swift; sourceTree = "<group>"; };
+		4255D4A61AB35116004CB409 /* SwiftViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SwiftViewController.swift; path = SwiftView/SwiftViewController.swift; sourceTree = "<group>"; };
 		426C0FC71A41606800F2577C /* information.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = information.png; sourceTree = "<group>"; };
 		426C0FC81A41606800F2577C /* information@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "information@2x.png"; sourceTree = "<group>"; };
 		426C0FC91A41606800F2577C /* information@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "information@3x.png"; sourceTree = "<group>"; };
@@ -191,6 +196,15 @@
 			path = ../YOLayout/AppKit;
 			sourceTree = "<group>";
 		};
+		4255D4A31AB350DE004CB409 /* SwiftView */ = {
+			isa = PBXGroup;
+			children = (
+				4255D4A51AB35116004CB409 /* CircleLayoutView.swift */,
+				4255D4A61AB35116004CB409 /* SwiftViewController.swift */,
+			);
+			name = SwiftView;
+			sourceTree = "<group>";
+		};
 		426C0FC61A41606800F2577C /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -251,6 +265,7 @@
 		42F5C2F01A3CAF3E00E37B78 /* YOLayoutExample */ = {
 			isa = PBXGroup;
 			children = (
+				4255D4A31AB350DE004CB409 /* SwiftView */,
 				426C0FDC1A41714900F2577C /* DynamicTableViewCells */,
 				005669491A9673D800CA236E /* BorderView */,
 				426C0FD61A41714900F2577C /* DrawableViews */,
@@ -264,6 +279,7 @@
 				426C0FD31A416CBE00F2577C /* GridView.h */,
 				426C0FD41A416CBE00F2577C /* GridView.m */,
 				426C0FE61A41725000F2577C /* LaunchScreen.xib */,
+				4255D4A41AB35115004CB409 /* YOLayoutExample-Bridging-Header.h */,
 			);
 			path = YOLayoutExample;
 			sourceTree = "<group>";
@@ -455,6 +471,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4255D4A81AB35116004CB409 /* SwiftViewController.swift in Sources */,
 				0056694C1A9673D800CA236E /* BorderView.m in Sources */,
 				42F5C31E1A3CAF7A00E37B78 /* YOCGUtils.m in Sources */,
 				426C0FE41A41714900F2577C /* TableViewCell.m in Sources */,
@@ -467,6 +484,7 @@
 				426C0FE51A41714900F2577C /* TableViewController.m in Sources */,
 				42F5C31F1A3CAF7A00E37B78 /* YOLayout_IMP.m in Sources */,
 				42C08D5C1A413749009B7E9E /* LogoView.m in Sources */,
+				4255D4A71AB35116004CB409 /* CircleLayoutView.swift in Sources */,
 				426C0FD51A416CBE00F2577C /* GridView.m in Sources */,
 				42F5C2F41A3CAF3E00E37B78 /* main.m in Sources */,
 			);
@@ -618,9 +636,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = YOLayoutExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "YOLayoutExample/YOLayoutExample-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -628,9 +649,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = YOLayoutExample/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "YOLayoutExample/YOLayoutExample-Bridging-Header.h";
 			};
 			name = Release;
 		};

--- a/YOLayoutExample/YOLayoutExample/LayoutExampleTableViewController.m
+++ b/YOLayoutExample/YOLayoutExample/LayoutExampleTableViewController.m
@@ -11,6 +11,7 @@
 #import "TableViewController.h"
 #import "DrawableViewController.h"
 #import "BorderViewController.h"
+#import "YOLayoutExample-swift.h"
 
 @interface LayoutExampleTableViewController ()
 
@@ -31,7 +32,7 @@
 }
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    return 3;
+    return 4;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
@@ -52,6 +53,14 @@
             cell.textLabel.text = @"Border Layout Example";
             cell.detailTextLabel.text = @"Dynamic top and bottom view with center filling the remaining space.";
             break;
+
+        case 3:
+            cell.textLabel.text = @"Swift Example";
+            cell.detailTextLabel.text = @"Use YOLayout with swift";
+            break;
+
+        default:
+            return nil;
     }
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
     
@@ -78,7 +87,12 @@
             [self.navigationController pushViewController:borderViewController animated:YES];
             break;
         }
-
+        case 3:
+        {
+            SwiftViewController *swiftViewController = [[SwiftViewController alloc] init];
+            [self.navigationController pushViewController:swiftViewController animated:YES];
+            break;
+        }
         default:
             break;
     }

--- a/YOLayoutExample/YOLayoutExample/SwiftView/CircleLayoutView.swift
+++ b/YOLayoutExample/YOLayoutExample/SwiftView/CircleLayoutView.swift
@@ -1,0 +1,50 @@
+//
+//  CircleLayoutView.swift
+//  YOLayoutExample
+//
+//  Created by John Boiles on 1/9/15.
+//  Copyright (c) 2015 YOLayout. All rights reserved.
+//
+
+//! A view lays out its subviews in a circle.. in Swift!
+class CircleLayoutView: YOView {
+    var imageViews = NSMutableArray()
+
+    override func viewInit() {
+        self.backgroundColor = UIColor(white: 0.96, alpha: 1)
+
+        // Create a set of subviews
+        for i in 0...7 {
+            let imageView = UIImageView(image: UIImage(named: "information.png"))
+            self.addSubview(imageView)
+        }
+
+        self.layout = YOLayout(layoutBlock: { [unowned self] (layout : YOLayoutProtocol!, size) -> CGSize in
+            var angle : CGFloat = 0;
+            let center = CGPointMake(size.width / 2, size.height / 2)
+            let subviewSize = CGSizeMake(44, 44)
+
+            // TODO: Switch this to `let` when Swift 1.2 is officially released
+            var radius : CGFloat;
+            if (size.width < size.height) {
+                radius = size.width / 2 - subviewSize.width / 2
+            } else {
+                radius = size.height / 2 - subviewSize.width / 2
+            }
+
+            // Lay out subviews in a circle around center
+            for subview in self.subviews {
+                let subviewCenter = CGPointMake(center.x + radius * CGFloat(cosf(Float(angle))), center.y + radius * CGFloat(sinf(Float(angle))))
+                layout.setFrame(CGRectMake(subviewCenter.x - subviewSize.width / 2, subviewCenter.y - subviewSize.height / 2, subviewSize.width, subviewSize.height), view:subview)
+                angle += CGFloat(M_PI_4)
+            }
+
+            // Always lay out in a square contained by size (aspect fit)
+            if (size.width < size.height) {
+                return CGSizeMake(size.width, size.width)
+            } else {
+                return CGSizeMake(size.height, size.height)
+            }
+        })
+    }
+}

--- a/YOLayoutExample/YOLayoutExample/SwiftView/SwiftViewController.swift
+++ b/YOLayoutExample/YOLayoutExample/SwiftView/SwiftViewController.swift
@@ -1,0 +1,49 @@
+//
+//  SwiftViewController.swift
+//  YOLayoutExample
+//
+//  Created by John Boiles on 1/9/15.
+//  Copyright (c) 2015 YOLayout. All rights reserved.
+//
+
+import UIKit
+
+class SwiftViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.edgesForExtendedLayout = .None;
+        self.title = "Swift Circle View"
+    }
+
+    override func loadView() {
+        super.loadView()
+
+        let swiftView = CircleLayoutView()
+
+        let informationLabel = UILabel()
+        informationLabel.textAlignment = .Center
+        informationLabel.lineBreakMode = .ByWordWrapping
+        informationLabel.numberOfLines = 0
+        informationLabel.text = "With YOLayout, you can build any layout you can imagine mathematically. The following view, written in Swift, uses trigonometry to layout subviews in a circle around the center. Try rotating the device."
+
+        // Use a simple container view to hold the informationLabel and the circleView after it sizes to fit
+        let containerView = YOView()
+        containerView.backgroundColor = UIColor.whiteColor()
+        containerView.layout = YOLayout(layoutBlock: { (layout: YOLayoutProtocol!, size) -> CGSize in
+            var y : CGFloat = 10;
+
+            y += layout.setFrame(CGRectMake(10, y, size.width - 20, 100), view: informationLabel, options:.SizeToFitVertical).size.height
+            y += 5
+
+            layout.setFrame(CGRectMake(5, y, size.width - 10 , size.height - y - 5), view:swiftView, options:.SizeToFit | .AlignCenter)
+
+            return size
+        })
+        containerView.addSubview(swiftView)
+        containerView.addSubview(informationLabel)
+
+        self.view = containerView;
+    }
+
+}

--- a/YOLayoutExample/YOLayoutExample/YOLayoutExample-Bridging-Header.h
+++ b/YOLayoutExample/YOLayoutExample/YOLayoutExample-Bridging-Header.h
@@ -1,0 +1,6 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "YOLayout.h"
+#import "YOView.h"


### PR DESCRIPTION
This kills two birds with one stone

* #13 - an example written in swift
* #39 - an example of a circular layout (something that I can't conceptualize using AutoLayout)

I also found a small bug preventing proper use of options in Swift. We needed to use `NS_OPTIONS` instead of `NS_ENUM` for `YOLayoutOptions`