### PR TITLE
Failing assert when using `YOLayoutOptionsSizeToFit` on `CALayer`

### DIFF
--- a/YOLayout/YOLayout_IMP.m
+++ b/YOLayout/YOLayout_IMP.m
@@ -109,6 +109,7 @@ const UIEdgeInsets UIEdgeInsetsZero = {0, 0, 0, 0};
 
   CGSize sizeThatFits = CGSizeZero;
   if (sizeToFit) {
+    NSAssert([view respondsToSelector:@selector(sizeThatFits:)], @"sizeThatFits: must be implemented on %@ for use with YOLayoutOptionsSizeToFit", view);
     sizeThatFits = [view sizeThatFits:size];
     
     // If size that fits returns a larger width, then we'll need to constrain it.


### PR DESCRIPTION
Or any other view that doesn't implement `sizeThatFits:`. This improves support for `CALayer`, Facebook AsyncDisplayKit's `ASNode` or anything else that implements `setFrame:` but not necessarily `sizeThatFits:`